### PR TITLE
fix: Now cannot click rapidly on Subscribe

### DIFF
--- a/lib/views/subscription_page.dart
+++ b/lib/views/subscription_page.dart
@@ -17,6 +17,9 @@ class SubscriptionPage extends StatefulWidget {
 }
 
 class _SubscriptionPageState extends State<SubscriptionPage> {
+  bool isSubscribing = false;
+  SubscriptionPlan? subscribingForPlan;
+
   @override
   Widget build(BuildContext context) {
     return BackofficePage(
@@ -129,8 +132,25 @@ class _SubscriptionPageState extends State<SubscriptionPage> {
               minWidth: double.infinity,
             ),
             child: LenraButton(
-              disabled: isNotCurrentPlan,
+              disabled: isNotCurrentPlan || isSubscribing,
+              rightIcon: isSubscribing && subscribingForPlan == plan
+                  ? Padding(
+                      padding: EdgeInsets.only(left: 8),
+                      child: SizedBox(
+                        height: 10,
+                        width: 10,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                        ),
+                      ),
+                    )
+                  : null,
               onPressed: () async {
+                setState(() {
+                  isSubscribing = true;
+                  subscribingForPlan = plan;
+                });
+
                 String? redirectUrl;
                 if (isCurrentPlan) {
                   redirectUrl = await StripeApi.getCustomerPortalUrl();
@@ -154,7 +174,9 @@ class _SubscriptionPageState extends State<SubscriptionPage> {
                   await Future.delayed(Duration(milliseconds: 100));
                 }
 
-                setState(() {});
+                setState(() {
+                  isSubscribing = false;
+                });
               },
               text: buttonText,
             ),


### PR DESCRIPTION
<!--
  For Work In Progress Pull Requests, please use the Draft PR feature,
  see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.
  
  Before submitting a Pull Request, please ensure you've done the following:
  - 👷‍♀️ Create small PRs. In most cases, this will be possible.
  - ✅ Provide tests for your changes.
  - 📜 Use Conventional Commit for your PR name (see https://www.conventionalcommits.org/en/v1.0.0/).
  - 📝 Use descriptive commit messages.
  - 📗 Update any related documentation and include any relevant screenshots.
-->



## About this PR
<!-- 
Link the related issue if any.
-->
Closes https://github.com/lenra-io/backoffice/issues/119
<!-- 
  - What is the bug/feature you make ? (If describe in the issue, don't repeat yourself, tell us)
  - Any other changes not in the issue ? Why did you add them ?
  - Add some scope to the changes if relevant
  - Try to give as much context as possible without any technical stuff here.

  For example : 
  We need some CGU in our app that the user must accept before doing anythig. See issue #42 for more informations.

  In this PR I've created : 
  - The CGU structure/database with a version for each CGU
  - the API to get the current CGU version for the user. 
  - The business logic to validate the CGU
  What is Out of scope : 
  - The mix task to create a new CGU
  - The Admin API to manage the CGU

  This is only back-end related stuff. For the front-end part, see this issue : #1337 
-->

## Technical highlight/advice
<!-- 
    This part is for technical stuff.
    - Tell us what did you change to implement the feature or fix the bug.
    - Don't detail it too much if it's simple stuff.
    - Add more information if you made significant changes that can affect others.

    For example : 
    To create the new API, I've created a new `CGUController` and a `CGU` Context.
    2 new routes : 
     - GET /api/cgu
     - POST /api/cgu/accept
    I've created a new table in the database with a migration.
    The CGU is linked to the user (Many to Many).
    I've added the rule to deny anyone that did not accept the CGU.
-->

## How to test my changes
<!-- 
  - How to start the project. Any other dependancies to update ? Any database migration ?
  - Step-by-step guide to reproduce the bug or test the new feature.

  Try to be rather explicit but keep it as simple as possible.

  Example : 
  - On server : 
    - `git checkout implement-cgu-validation`
    - `mix ecto.reset`
    - `mix ecto.migrate`
    - `mix phx.server`
  Use the thunder client in vscode : 
  - Register/Login (get the token)
  - Try to access this api without validating CGU : GET /api/apps. It should fail.
  - Validate the CGU ising the API POST /api/cgu/accept
  - Access the API agail, now it should work.
-->


## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one

### I included unit tests that cover my changes
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### I added/updated the documentation about my changes
- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [x] 🙅 no documentation needed


