### PR TITLE
fix: Overview builds load

### DIFF
--- a/lib/views/overview_page.dart
+++ b/lib/views/overview_page.dart
@@ -35,18 +35,22 @@ class _OverviewPageState extends State<OverviewPage> {
 
     UserApplicationModel userApplicationModel = context.read<UserApplicationModel>();
 
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      userApplicationModel.fetchUserApplications().then(
-        (_) {
-          setState(() {
-            app = userApplicationModel.getApp(widget.appId);
-          });
+    WidgetsBinding.instance.addPostFrameCallback((_) async {
+      await userApplicationModel.fetchUserApplications().then(
+        (_) async {
+          AppResponse? app = userApplicationModel.getApp(widget.appId);
 
           if (app == null) {
             CommonNavigator.go(context, BackofficeNavigator.selectProject);
           } else {
-            buildModel.fetchBuilds(widget.appId);
-            deploymentModel.fetchDeployments(widget.appId);
+            await Future.wait([
+              buildModel.fetchBuilds(widget.appId),
+              deploymentModel.fetchDeployments(widget.appId),
+            ]);
+
+            setState(() {
+              this.app = app;
+            });
           }
         },
       );


### PR DESCRIPTION
## About this PR

There was a problem with the loading of the builds and deployment at first load of the overview page. We did not wait for the fetchBuilds and fetchDeployments requests to be done before loading the UI which caused the UI to not have the data unless clicking on "settings" and coming back to the overview.

I added an await for the two requests before calling setState which solves the issue.

We might want to rework this page in the future but this does not really have a high priority.

## Technical highlight/advice

## How to test my changes

Run the server as usual.
Run the backoffice as usual.

Create an application and try to deploy it. Reload the overview page, you should properly see the build in progress.

## Checklist
- [x] I didn't over-scope my PR
- [x] My PR title matches the [commit convention](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] I did not include breaking changes
- [x] I made my own code-review before requesting one

### I included unit tests that cover my changes
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

### I added/updated the documentation about my changes
- [ ] 📜 README.md
- [ ] 📕 docs/*.md
- [ ] 📓 docs.lenra.io
- [x] 🙅 no documentation needed


